### PR TITLE
Task統計API(GET /tasks/report)を新規実装 #3

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,6 +6,11 @@ class TasksController < ApplicationController
     tasks_all
   end
 
+  def report
+    result = Tasks::ReportService.call
+    @report = result.data
+  end
+
   def create
     result = Tasks::CreateService.call(create_params)
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,15 +2,15 @@ class Task < ApplicationRecord
   belongs_to :genre
 
   enum :priority, { low: 0, medium: 1, high: 2 }
+  enum :status, { not_started: 0, in_progress: 1, completed: 2 }
 
-  INITIAL_STATUS = 0
   COPY_SUFFIX = '（コピー）'
   DUPLICATABLE_ATTRIBUTES = %w[name explanation genre_id priority].freeze
 
   def build_duplicate
     attrs = attributes.slice(*DUPLICATABLE_ATTRIBUTES)
     attrs["name"] = "#{attrs['name']}#{COPY_SUFFIX}"
-    attrs["status"] = INITIAL_STATUS
+    attrs["status"] = :not_started
     attrs["deadline_date"] = nil
 
     Task.new(attrs)

--- a/app/services/tasks/report_service.rb
+++ b/app/services/tasks/report_service.rb
@@ -1,0 +1,27 @@
+module Tasks
+  class ReportService < ApplicationService
+    def call
+      total_count = Task.count
+      counts = Task.group(:status).count
+      completed_count = counts['completed'] || 0
+
+      count_by_status = {
+        not_started: counts['not_started'] || 0,
+        in_progress: counts['in_progress'] || 0,
+        completed: completed_count
+      }
+
+      completion_rate = if total_count.zero?
+                          0.0
+                        else
+                          (completed_count.to_f / total_count * 100).round(1)
+                        end
+
+      ServiceResult.success(
+        total_count: total_count,
+        count_by_status: count_by_status,
+        completion_rate: completion_rate
+      )
+    end
+  end
+end

--- a/app/views/tasks/report.json.jbuilder
+++ b/app/views/tasks/report.json.jbuilder
@@ -1,0 +1,7 @@
+json.totalCount @report[:total_count]
+json.countByStatus do
+  json.notStarted @report[:count_by_status][:not_started]
+  json.inProgress @report[:count_by_status][:in_progress]
+  json.completed @report[:count_by_status][:completed]
+end
+json.completionRate @report[:completion_rate]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  resources :tasks , defaults: {format: 'json'} do
+  resources :tasks, defaults: { format: 'json' } do
+    collection do
+      get :report
+    end
     member do
       post :status, to: "tasks#update_status", defaults: {format: 'json'}
       post :duplicate, defaults: {format: 'json'}

--- a/spec/services/tasks/create_service_spec.rb
+++ b/spec/services/tasks/create_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Tasks::CreateService do
           genreId: genre.id,
           deadlineDate: '2026-12-31',
           priority: 'high',
-          status: 1
+          status: :in_progress
         }
       end
 
@@ -40,7 +40,7 @@ RSpec.describe Tasks::CreateService do
         expect(task.genre_id).to eq(genre.id)
         expect(task.deadline_date).to eq(Date.parse('2026-12-31'))
         expect(task.priority).to eq('high')
-        expect(task.status).to eq(1)
+        expect(task.status).to eq('in_progress')
       end
 
       it 'camelCase パラメータを snake_case に変換すること' do

--- a/spec/services/tasks/duplicate_service_spec.rb
+++ b/spec/services/tasks/duplicate_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Tasks::DuplicateService do
       explanation: 'タスクの説明文',
       genre: genre,
       priority: :medium,
-      status: 0,
+      status: :not_started,
       deadline_date: '2026-12-31'
     )
   end
@@ -46,21 +46,21 @@ RSpec.describe Tasks::DuplicateService do
 
     context '特別な処理' do
       it 'コピー元が進行中でも status が未着手（初期ステータス）になること' do
-        original_task.update!(status: 1)
+        original_task.update!(status: :in_progress)
 
         result = described_class.call(original_task)
         task = result.data
 
-        expect(task.status).to eq(0)
+        expect(task.status).to eq('not_started')
       end
 
       it 'コピー元が完了でも status が未着手（初期ステータス）になること' do
-        original_task.update!(status: 2)
+        original_task.update!(status: :completed)
 
         result = described_class.call(original_task)
         task = result.data
 
-        expect(task.status).to eq(0)
+        expect(task.status).to eq('not_started')
       end
 
       it 'コピー元に deadline_date があっても nil になること' do

--- a/spec/services/tasks/report_service_spec.rb
+++ b/spec/services/tasks/report_service_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe Tasks::ReportService do
+  let(:genre) { Genre.create!(name: 'テストジャンル') }
+
+  describe '.call' do
+    context 'タスクが存在しない場合' do
+      it '成功すること' do
+        result = described_class.call
+
+        expect(result).to be_success
+      end
+
+      it 'totalCount が 0 であること' do
+        result = described_class.call
+
+        expect(result.data[:total_count]).to eq(0)
+      end
+
+      it 'countByStatus が全て 0 であること' do
+        result = described_class.call
+
+        expect(result.data[:count_by_status]).to eq(
+          not_started: 0,
+          in_progress: 0,
+          completed: 0
+        )
+      end
+
+      it 'completionRate が 0.0 であること' do
+        result = described_class.call
+
+        expect(result.data[:completion_rate]).to eq(0.0)
+      end
+    end
+
+    context 'タスクが存在する場合' do
+      before do
+        Task.create!(name: 'タスク1', genre: genre, status: :not_started)
+        Task.create!(name: 'タスク2', genre: genre, status: :not_started)
+        Task.create!(name: 'タスク3', genre: genre, status: :in_progress)
+        Task.create!(name: 'タスク4', genre: genre, status: :completed)
+      end
+
+      it '成功すること' do
+        result = described_class.call
+
+        expect(result).to be_success
+      end
+
+      it 'totalCount が正しいこと' do
+        result = described_class.call
+
+        expect(result.data[:total_count]).to eq(4)
+      end
+
+      it 'countByStatus が正しいこと' do
+        result = described_class.call
+
+        expect(result.data[:count_by_status]).to eq(
+          not_started: 2,
+          in_progress: 1,
+          completed: 1
+        )
+      end
+
+      it 'completionRate が正しいこと' do
+        result = described_class.call
+
+        expect(result.data[:completion_rate]).to eq(25.0)
+      end
+    end
+
+    context '完了率の小数点計算' do
+      before do
+        Task.create!(name: 'タスク1', genre: genre, status: :not_started)
+        Task.create!(name: 'タスク2', genre: genre, status: :completed)
+        Task.create!(name: 'タスク3', genre: genre, status: :completed)
+      end
+
+      it '小数点以下1桁で丸められること' do
+        result = described_class.call
+
+        expect(result.data[:completion_rate]).to eq(66.7)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Tasks::ReportServiceで統計ロジックを実装（totalCount, countByStatus, completionRate）
- Taskモデルにstatusのenumを追加し、マジックナンバーを排除
- 既存テストのstatus値をenumシンボルに統一